### PR TITLE
Add Docker support and keepalive in `src/core/proxy.rs`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
-**/target/
+target/
+.git/
+.github/
 data/
-*.apk
+doc/
 *.zip
+*.apk
 *.o
 *.d
 CACHEDIR.TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,13 +33,11 @@ RUN set -eux; \
     mkdir -p /out; \
     cp "target/${rust_target}/release/iwan-client-oidc" /out/iwan-client-oidc
 
-FROM debian:bookworm-slim AS proxy-builder
+FROM alpine:3.22 AS proxy-builder
 
 ARG THREEPROXY_VERSION=0.9.5
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gcc libc6-dev make \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base ca-certificates curl linux-headers
 
 WORKDIR /src
 RUN curl -fsSL "https://github.com/3proxy/3proxy/archive/refs/tags/${THREEPROXY_VERSION}.tar.gz" -o /tmp/3proxy.tar.gz \
@@ -48,11 +46,9 @@ RUN curl -fsSL "https://github.com/3proxy/3proxy/archive/refs/tags/${THREEPROXY_
     && mkdir -p /out \
     && cp bin/3proxy /out/3proxy
 
-FROM debian:bookworm-slim AS runtime
+FROM alpine:3.22 AS runtime
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl iproute2 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl iproute2
 
 COPY --from=builder /out/iwan-client-oidc /usr/local/bin/iwan-client-oidc
 COPY --from=proxy-builder /out/3proxy /usr/local/bin/3proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1-bookworm AS builder
+
+ARG TARGETARCH
+ARG ZIG_VERSION=0.13.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz \
+    && mkdir -p /opt/zig \
+    && tar -xf /tmp/zig.tar.xz -C /opt/zig --strip-components=1 \
+    && rm /tmp/zig.tar.xz
+
+ENV PATH="/opt/zig:${PATH}"
+
+RUN cargo install cargo-zigbuild --locked
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) rust_target="x86_64-unknown-linux-musl" ;; \
+        arm64) rust_target="aarch64-unknown-linux-musl" ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}; supported: amd64, arm64" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "${rust_target}"; \
+    cargo zigbuild --bin iwan-client-oidc --target "${rust_target}" --release; \
+    mkdir -p /out; \
+    cp "target/${rust_target}/release/iwan-client-oidc" /out/iwan-client-oidc
+
+FROM debian:bookworm-slim AS proxy-builder
+
+ARG THREEPROXY_VERSION=0.9.5
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gcc libc6-dev make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN curl -fsSL "https://github.com/3proxy/3proxy/archive/refs/tags/${THREEPROXY_VERSION}.tar.gz" -o /tmp/3proxy.tar.gz \
+    && tar -xf /tmp/3proxy.tar.gz -C /src --strip-components=1 \
+    && make -f Makefile.Linux \
+    && mkdir -p /out \
+    && cp bin/3proxy /out/3proxy
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/iwan-client-oidc /usr/local/bin/iwan-client-oidc
+COPY --from=proxy-builder /out/3proxy /usr/local/bin/3proxy
+COPY docker/3proxy.cfg /etc/3proxy/3proxy.cfg
+COPY docker/iwan-entrypoint.sh /usr/local/bin/iwan-entrypoint
+COPY docker/iwan-healthcheck.sh /usr/local/bin/iwan-healthcheck
+
+RUN chmod +x /usr/local/bin/iwan-client-oidc /usr/local/bin/3proxy /usr/local/bin/iwan-entrypoint /usr/local/bin/iwan-healthcheck \
+    && mkdir -p /config
+
+VOLUME ["/config"]
+EXPOSE 1080 8888
+HEALTHCHECK --interval=150s --timeout=5s --start-period=90s --retries=3 CMD iwan-healthcheck
+
+ENTRYPOINT ["iwan-entrypoint"]
+CMD ["auto"]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,73 @@ sudo ./iwan-client-oidc --connect --proxy-cidr 0.0.0.0/0
 
 必须指定 `--fetch`、`--list`、`--connect`、`--all` 中的至少一个动作。
 
+## Docker 代理模式
+
+用于把 `iwan-client-oidc` 封装成宿主机可用的本地代理镜像，暴露给宿主机的代理端口为：
+
+- SOCKS5：`127.0.0.1:1080`
+- HTTP：`127.0.0.1:8888`
+
+容器内会先建立 iWAN TUN 隧道，再启动 [3proxy](https://github.com/3proxy/3proxy)。宿主机本地代理端口后，代理进程的出站流量会走容器内的 iWAN 隧道。
+
+构建镜像：
+
+```bash
+docker build -f Dockerfile -t ustc-iwan-client-oidc .
+# 或 docker compose build
+```
+
+启动代理：
+
+```bash
+docker run -it \
+  --name ustc-iwan \
+  --restart unless-stopped \
+  --cap-add NET_ADMIN \
+  --device /dev/net/tun \
+  --sysctl net.ipv6.conf.all.disable_ipv6=1 \
+  --sysctl net.ipv6.conf.default.disable_ipv6=1 \
+  --sysctl net.ipv6.conf.lo.disable_ipv6=1 \
+  -p 127.0.0.1:1080:1080 \
+  -p 127.0.0.1:8888:8888 \
+  -v "$PWD/data/iwan:/config" \
+  ustc-iwan-client-oidc
+```
+
+如果 `/config/servers.json` 不存在，容器会先输出 OIDC 登录链接。按前文流程在同一交互式命令行完成浏览器认证后，把回调 URL 粘贴回终端。随后容器会列出线路，选择一次后会保存该线路编号。配置会保存到宿主机的：
+
+```text
+./data/iwan/servers.json
+```
+
+线路选择会保存到：
+
+```text
+./data/iwan/server_index
+```
+
+后续启动或重启会直接复用已保存的登录配置和线路选择：
+
+```bash
+docker start ustc-iwan
+docker restart ustc-iwan
+```
+
+测试宿主机访问测试：
+
+```bash
+curl --proxy socks5h://127.0.0.1:1080 https://api.llm.ustc.edu.cn
+curl --proxy http://127.0.0.1:8888 https://api.llm.ustc.edu.cn
+```
+
+排查日志：
+
+```bash
+docker logs ustc-iwan
+```
+
+默认禁用 IPv6，避免 TUN 刚启动时产生 IPv6 链路本地流量影响 iWAN 数据面。端口只绑定到 `127.0.0.1`，不会暴露到局域网。
+
 ## 手动客户端
 
 `iwan-client` 不使用 OIDC，需要手动提供服务器、用户名和密码。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  iwan:
+    build:
+      context: .
+    image: ustc-iwan-client-oidc
+    container_name: ustc-iwan
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: "1"
+      net.ipv6.conf.default.disable_ipv6: "1"
+      net.ipv6.conf.lo.disable_ipv6: "1"
+    ports:
+      - "127.0.0.1:1080:1080"
+      - "127.0.0.1:8888:8888"
+    environment:
+      IWAN_PROXY_CIDR: "0.0.0.0/0"
+    volumes:
+      - ./data/iwan:/config

--- a/docker/3proxy.cfg
+++ b/docker/3proxy.cfg
@@ -1,0 +1,8 @@
+nscache 65536
+timeouts 1 5 30 60 180 1800 15 60
+
+auth none
+allow *
+
+socks -p1080 -i0.0.0.0
+proxy -p8888 -i0.0.0.0

--- a/docker/iwan-entrypoint.sh
+++ b/docker/iwan-entrypoint.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+set -eu
+
+CONFIG_DIR="${IWAN_CONFIG_DIR:-/config}"
+SERVER_INDEX_FILE="${IWAN_SERVER_INDEX_FILE:-${CONFIG_DIR}/server_index}"
+IWAN_TUN="${IWAN_TUN:-iwan0}"
+IWAN_SERVER_INDEX="${IWAN_SERVER_INDEX:-}"
+IWAN_PROXY_CIDR="${IWAN_PROXY_CIDR:-0.0.0.0/0}"
+IWAN_PROXY_IP="${IWAN_PROXY_IP:-}"
+IWAN_PROXY_DOMAIN="${IWAN_PROXY_DOMAIN:-}"
+IWAN_ENCRYPT="${IWAN_ENCRYPT:-1}"
+THREEPROXY_CONFIG="${THREEPROXY_CONFIG:-/etc/3proxy/3proxy.cfg}"
+
+mode="auto"
+iwan_pid=""
+proxy_pid=""
+EXTRA_ARGS=""
+
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        --fetch) mode="fetch"; shift ;;
+        --list) mode="list"; shift ;;
+        --connect) mode="connect"; shift ;;
+        --auto) mode="auto"; shift ;;
+        fetch|list|connect|auto) mode="$1"; shift ;;
+        *) mode="command" ;;
+    esac
+fi
+
+EXTRA_ARGS="$*"
+
+run_simple_mode() {
+    case "$mode" in
+        fetch)
+            exec iwan-client-oidc --config-dir "$CONFIG_DIR" --fetch "$@"
+            ;;
+        list)
+            exec iwan-client-oidc --config-dir "$CONFIG_DIR" --list "$@"
+            ;;
+        command)
+            exec "$@"
+            ;;
+    esac
+}
+
+ensure_config() {
+    if [ -s "$CONFIG_DIR/servers.json" ]; then
+        return
+    fi
+
+    if [ "$mode" = "auto" ]; then
+        echo "missing $CONFIG_DIR/servers.json; starting OIDC login" >&2
+        iwan-client-oidc --config-dir "$CONFIG_DIR" --fetch
+    fi
+
+    if [ ! -s "$CONFIG_DIR/servers.json" ]; then
+        echo "missing $CONFIG_DIR/servers.json; start this container interactively once" >&2
+        exit 1
+    fi
+}
+
+choose_server() {
+    if [ -n "$IWAN_SERVER_INDEX" ]; then
+        server_index="$IWAN_SERVER_INDEX"
+    elif [ -s "$SERVER_INDEX_FILE" ]; then
+        server_index="$(tr -cd '0-9' < "$SERVER_INDEX_FILE")"
+    else
+        iwan-client-oidc --config-dir "$CONFIG_DIR" --list
+        printf '  Select server to save for this container: '
+        read -r server_index
+        server_index="$(printf '%s' "$server_index" | tr -cd '0-9')"
+        [ -n "$server_index" ] || {
+            echo "invalid server selection" >&2
+            exit 1
+        }
+        printf '%s\n' "$server_index" > "$SERVER_INDEX_FILE"
+    fi
+
+    if [ -z "$server_index" ]; then
+        echo "empty server selection; remove $SERVER_INDEX_FILE and start interactively again" >&2
+        exit 1
+    fi
+}
+
+build_iwan_command() {
+    set -- iwan-client-oidc \
+        --config-dir "$CONFIG_DIR" \
+        --connect \
+        --tun "$IWAN_TUN" \
+        --encrypt "$IWAN_ENCRYPT"
+
+    [ -n "$IWAN_PROXY_CIDR" ] && set -- "$@" --proxy-cidr "$IWAN_PROXY_CIDR"
+    [ -n "$IWAN_PROXY_IP" ] && set -- "$@" --proxy-ip "$IWAN_PROXY_IP"
+    [ -n "$IWAN_PROXY_DOMAIN" ] && set -- "$@" --proxy-domain "$IWAN_PROXY_DOMAIN"
+
+    IWAN_COMMAND="$*"
+}
+
+start_iwan() {
+    build_iwan_command
+    # IWAN_COMMAND and EXTRA_ARGS are simple CLI fragments controlled by env vars.
+    printf '%s\n' "$server_index" | sh -c 'exec "$@"' sh $IWAN_COMMAND $EXTRA_ARGS &
+    iwan_pid="$!"
+}
+
+wait_for_tun() {
+    for _ in $(seq 1 60); do
+        if ! kill -0 "$iwan_pid" 2>/dev/null; then
+            wait "$iwan_pid"
+            exit $?
+        fi
+        if ip -4 addr show dev "$IWAN_TUN" 2>/dev/null | grep -q 'inet '; then
+            return
+        fi
+        sleep 1
+    done
+
+    echo "timed out waiting for $IWAN_TUN to become ready" >&2
+    cleanup
+    exit 1
+}
+
+start_proxy() {
+    3proxy "$THREEPROXY_CONFIG" &
+    proxy_pid="$!"
+}
+
+monitor_processes() {
+    while true; do
+        if ! kill -0 "$iwan_pid" 2>/dev/null; then
+            wait "$iwan_pid"
+            exit $?
+        fi
+        if ! kill -0 "$proxy_pid" 2>/dev/null; then
+            wait "$proxy_pid"
+            exit $?
+        fi
+        sleep 2
+    done
+}
+
+cleanup() {
+    [ -z "$proxy_pid" ] || kill "$proxy_pid" 2>/dev/null || true
+    [ -z "$iwan_pid" ] || kill "$iwan_pid" 2>/dev/null || true
+}
+
+trap cleanup INT TERM
+
+run_simple_mode "$@"
+ensure_config
+choose_server
+start_iwan
+wait_for_tun
+start_proxy
+monitor_processes

--- a/docker/iwan-healthcheck.sh
+++ b/docker/iwan-healthcheck.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+IWAN_TUN="${IWAN_TUN:-iwan0}"
+IWAN_HEALTHCHECK_URL="${IWAN_HEALTHCHECK_URL:-http://www.gstatic.com/generate_204}"
+IWAN_HEALTHCHECK_TIMEOUT="${IWAN_HEALTHCHECK_TIMEOUT:-1}"
+
+has_process() {
+    name="$1"
+    for comm in /proc/[0-9]*/comm; do
+        [ -r "$comm" ] || continue
+        [ "$(cat "$comm")" = "$name" ] && return 0
+    done
+    return 1
+}
+
+listens_on() {
+    port="$1"
+    ss -ltn | grep -Eq "[.:]${port}[[:space:]]"
+}
+
+has_process iwan-client-oid || {
+    echo "iwan-client-oidc is not running" >&2
+    exit 1
+}
+
+has_process 3proxy || {
+    echo "3proxy is not running" >&2
+    exit 1
+}
+
+ip -4 addr show dev "$IWAN_TUN" 2>/dev/null | grep -q 'inet ' || {
+    echo "$IWAN_TUN has no IPv4 address" >&2
+    exit 1
+}
+
+ip route show default dev "$IWAN_TUN" | grep -q '^default ' || {
+    echo "default route does not use $IWAN_TUN" >&2
+    exit 1
+}
+
+listens_on 1080 || {
+    echo "SOCKS5 port 1080 is not listening" >&2
+    exit 1
+}
+
+listens_on 8888 || {
+    echo "HTTP proxy port 8888 is not listening" >&2
+    exit 1
+}
+
+check_url_with_proxy() {
+    name="$1"
+    proxy="$2"
+
+    output="$(curl -fsS --max-time "$IWAN_HEALTHCHECK_TIMEOUT" --proxy "$proxy" "$IWAN_HEALTHCHECK_URL" 2>&1)" || {
+        echo "$name proxy cannot access $IWAN_HEALTHCHECK_URL via $proxy" >&2
+        echo "$output" >&2
+        return 1
+    }
+}
+
+failed=0
+
+check_url_with_proxy "HTTP" "http://127.0.0.1:8888" || failed=1
+check_url_with_proxy "SOCKS5" "socks5h://127.0.0.1:1080" || failed=1
+
+exit "$failed"

--- a/src/core/proxy.rs
+++ b/src/core/proxy.rs
@@ -48,12 +48,35 @@ pub fn run_pump(
     let running = Arc::new(AtomicBool::new(true));
     let sock_send = sock.try_clone().context("clone send socket")?;
     let sock_recv = sock.try_clone().context("clone recv socket")?;
+    let sock_keepalive = sock.try_clone().context("clone keepalive socket")?;
     sock_recv
         .set_read_timeout(Some(Duration::from_millis(300)))
         .ok();
 
     let xk_send = xk.to_vec();
     let xk_recv = xk.to_vec();
+
+    let rk = running.clone();
+    let tk = std::thread::spawn(move || {
+        println!("[KEEPALIVE] started");
+        let h = protocol::pkhdr(protocol::PT_DATA_ENC, enc, sid, tok);
+        let pkt = protocol::data_pkt(&h, &[]);
+        loop {
+            if sock_keepalive.send(&pkt).is_err() {
+                eprintln!("[KEEPALIVE] send failed");
+                rk.store(false, Ordering::Relaxed);
+                break;
+            }
+            for _ in 0..100 {
+                if !rk.load(Ordering::Relaxed) {
+                    println!("[KEEPALIVE] stopped");
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+        }
+        println!("[KEEPALIVE] stopped");
+    });
 
     let r1 = running.clone();
     let t1 = std::thread::spawn(move || {
@@ -110,6 +133,8 @@ pub fn run_pump(
                         eprintln!("[UDP→TUN] server sent CLOSE");
                         r2.store(false, Ordering::Relaxed);
                         break;
+                    } else if t == protocol::PT_PING_RSP && protocol::verify_sig(&buf[..n]) {
+                        // Keepalive response; the data plane only needs it to keep NAT/session state fresh.
                     }
                 }
                 Ok(_) => {}
@@ -135,6 +160,7 @@ pub fn run_pump(
     while running.load(Ordering::Relaxed) {
         std::thread::sleep(Duration::from_millis(200));
     }
+    tk.join().ok();
     t1.join().ok();
     t2.join().ok();
 


### PR DESCRIPTION
将 iwan-client-oidc 封装进 docker 内, 暴露给宿主机 `127.0.0.1:1080` 和 `127.0.0.1:8888`, 进而可以实现与宿主机的 clash 等代理软件的集成.

1. 构建并启动容器

```bash
docker build -f Dockerfile -t ustc-iwan-client-oidc .

docker run -it \
  --name ustc-iwan \
  --restart unless-stopped \
  --cap-add NET_ADMIN \
  --device /dev/net/tun \
  --sysctl net.ipv6.conf.all.disable_ipv6=1 \
  --sysctl net.ipv6.conf.default.disable_ipv6=1 \
  --sysctl net.ipv6.conf.lo.disable_ipv6=1 \
  -p 127.0.0.1:1080:1080 \
  -p 127.0.0.1:8888:8888 \
  ustc-iwan-client-oidc
```

2. 增加 clash 配置, 利用 clash 进行分流, 同时不影响其他网络分流

参考 clash 配置:

```yaml
proxies:
    - type: "http"
      name: "ustc_http"
      server: "127.0.0.1"
      port: 8888
    - type: "socks5"
      name: "ustc_socks5"
      server: "127.0.0.1"
      port: 1080
proxy-groups:
    - name: "ustc"
      type: "fallback"
      url: "http://www.gstatic.com/generate_204"
      interval: 150
      timeout: 1000
      lazy: true
      proxies:
        - "ustc_http"
        - "ustc_socks5"
        - "DIRECT"
rules:
    - DOMAIN-SUFFIX,ustc.edu.cn,ustc
```