### PR TITLE
fix: 使用空数据帧维持 SOCKS5 隧道会话

### DIFF
--- a/src/core/netstack/tunnel.rs
+++ b/src/core/netstack/tunnel.rs
@@ -6,7 +6,7 @@ use std::io::ErrorKind;
 use std::net::{Ipv4Addr, UdpSocket};
 use std::time::{Duration, Instant};
 
-pub(crate) const VPN_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+pub(crate) const VPN_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn receive_vpn(
@@ -75,9 +75,18 @@ pub(crate) fn send_vpn_keepalive(
     if last_keepalive.elapsed() < VPN_KEEPALIVE_INTERVAL {
         return Ok(());
     }
-    let header = protocol::pkhdr(protocol::PT_PING_REQ, encryption, sid, token);
-    sock.send(&protocol::ctrl_pkt(&header, &[]))
-        .context("send VPN keepalive")?;
+    // Send an empty data frame so the keepalive is associated with
+    // the authenticated sid/token data session.
+    let packet_type = if encryption == 0 {
+        protocol::PT_DATA
+    } else {
+        protocol::PT_DATA_ENC
+    };
+
+    let header = protocol::pkhdr(packet_type, encryption, sid, token);
+    sock.send(&protocol::data_pkt(&header, &[]))
+        .context("send VPN session keepalive")?;
+
     *last_keepalive = Instant::now();
     Ok(())
 }


### PR DESCRIPTION

## 修复说明



修复 SOCKS5 模式下，iWAN 服务端在连接建立约 30～60 秒后主动关闭隧道会话的问题。 



原 SOCKS5 实现使用 `PT_PING_REQ` 控制报文作为会话保活。本次修改改为定期发送一个关联当前认证会话的空数据帧：



- 开启加密时使用 `PT_DATA_ENC`

- 未开启加密时使用 `PT_DATA`

- 携带当前会话的 `sid` 和 `token`

- 数据载荷为空



同时，将保活间隔从 10 秒调整为 20 秒。



## 问题表现



修改前，SOCKS5 代理建立连接后可以短暂正常使用，但 USTC iWAN 服务端通常会在约 45～60 秒后发送 `PT_CLOSE`，关闭底层 VPN 会话。



在会话关闭前，单次 HTTPS 请求能够正常完成，因此认证、SOCKS5 握手和基本数据转发均可以工作。



典型错误如下：

Error: VPN server closed the session after 5x seconds