### PR TITLE
feat: support non-interactive server selection and custom DNS resolvers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,12 +526,14 @@ dependencies = [
  "libc",
  "md-5",
  "rand",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
  "smoltcp",
  "ureq",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ url = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.8"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+webpki-roots = "0.26"
 smoltcp = { version = "0.13", default-features = false, features = [
     "std",
     "medium-ip",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ sudo ./iwan-client-oidc --connect
 
 命令会读取本地配置并显示线路列表。输入序号后，只解密所选线路的密码，并建立 TUN 隧道。
 
+也可以用 `--server` 跳过交互选择，适合脚本或 systemd 无人值守启动：
+
+```bash
+sudo ./iwan-client-oidc --connect --server 电信
+```
+
+`--server` 接受线路序号（如 `2`）或线路名称中的关键字（如 `电信`）。
+
 配置用普通用户执行 `--fetch` 保存即可。连接时即使使用 `sudo`，也不需要把配置文件复制到 root 用户目录。
 
 ### 无 TUN 的 SOCKS5 模式
@@ -143,7 +151,19 @@ Windows ARM64 请将文件名替换为
 `--socks-listen` 和 `--socks-mtu` 修改这两个值。
 
 当前 SOCKS5 模式支持 `CONNECT`、IPv4 地址目标和域名目标。域名由客户端
-通过固定的 `114.114.114.114:53` 在本机解析为 IPv4 地址，例如：
+在本机解析为 IPv4 地址，默认使用 `114.114.114.114:53`，可以通过
+`--dns` 指定其他解析器：
+
+```text
+--dns 223.5.5.5              # 普通 UDP（可带端口：223.5.5.5:5353）
+--dns tls://dns.alidns.com   # DNS over TLS（默认端口 853）
+--dns https://dns.alidns.com/dns-query   # DNS over HTTPS
+```
+
+当本机 DNS 被代理工具接管（如 TUN + fake-ip）时，建议改用 DoT 或 DoH，
+避免解析到假地址。
+
+使用示例：
 
 ```bash
 curl --socks5-hostname 127.0.0.1:1080 https://www.example.com/

--- a/src/bin/client/cli.rs
+++ b/src/bin/client/cli.rs
@@ -93,4 +93,7 @@ pub struct SocksArgs {
     /// Local SOCKS5 listen address.
     #[arg(long, default_value = "127.0.0.1:1080")]
     pub listen: std::net::SocketAddr,
+    /// DNS resolver for domain requests: ip[:port], tls://host[:port] or https://url.
+    #[arg(long, default_value = "114.114.114.114:53")]
+    pub dns: String,
 }

--- a/src/bin/client/socks.rs
+++ b/src/bin/client/socks.rs
@@ -4,6 +4,8 @@ use iwan::core::{auth, crypto, socks};
 use std::time::Duration;
 
 pub fn run(args: &cli::SocksArgs) -> Result<()> {
+    let dns = socks::DnsResolver::parse(&args.dns)
+        .with_context(|| format!("invalid --dns value {}", args.dns))?;
     let ct = auth::get_ct(&args.user, &args.pass, &args.ct_pass);
     let nonce = auth::rand_u32()?;
     let open = auth::build_open(&args.user, &ct, args.mtu, args.encrypt, nonce);
@@ -52,6 +54,7 @@ pub fn run(args: &cli::SocksArgs) -> Result<()> {
             sid: authenticated.sid,
             token: authenticated.tok,
             encryption: args.encrypt,
+            dns,
         },
     )
 }

--- a/src/bin/client/socks.rs
+++ b/src/bin/client/socks.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 pub fn run(args: &cli::SocksArgs) -> Result<()> {
     let dns = socks::DnsResolver::parse(&args.dns)
-        .with_context(|| format!("invalid --dns value {}", args.dns))?;
+        .with_context(|| format!("invalid --dns value {:?}", args.dns))?;
     let ct = auth::get_ct(&args.user, &args.pass, &args.ct_pass);
     let nonce = auth::rand_u32()?;
     let open = auth::build_open(&args.user, &ct, args.mtu, args.encrypt, nonce);

--- a/src/bin/oidc/cli.rs
+++ b/src/bin/oidc/cli.rs
@@ -22,6 +22,10 @@ pub struct Cli {
     #[arg(long)]
     pub connect: bool,
 
+    /// Server to connect to: name keyword or 1-based index. Skips interactive selection.
+    #[arg(long)]
+    pub server: Option<String>,
+
     /// Fetch config, print servers, choose one, and connect.
     #[arg(long)]
     pub all: bool,
@@ -62,4 +66,8 @@ pub struct Cli {
     /// Maximum userspace inner IP MTU.
     #[arg(long, default_value = "1380")]
     pub socks_mtu: u16,
+
+    /// DNS resolver for SOCKS5 domain requests: ip[:port], tls://host[:port] or https://url.
+    #[arg(long, default_value = "114.114.114.114:53")]
+    pub dns: String,
 }

--- a/src/bin/oidc/main.rs
+++ b/src/bin/oidc/main.rs
@@ -159,7 +159,9 @@ fn connect_server(cli: &cli::Cli, config: &LocalConfig) -> Result<()> {
         anyhow::bail!("no servers in config");
     }
 
-    let srv = select_server(&config.servers)?;
+    let dns = iwan::core::socks::DnsResolver::parse(&cli.dns)
+        .with_context(|| format!("invalid --dns value {}", cli.dns))?;
+    let srv = select_server(&config.servers, cli.server.as_deref())?;
     let host = srv["host"].as_str().context("missing host")?;
     let port = srv["port"].as_u64().unwrap_or(6001) as u16;
     let srv_user = srv["username"].as_str().unwrap_or("");
@@ -206,7 +208,7 @@ fn connect_server(cli: &cli::Cli, config: &LocalConfig) -> Result<()> {
     let xk: Vec<u8> = sk[..8].to_vec();
 
     if socks_mode(cli) {
-        return run_socks(cli, &sock, &xk, &auth_result);
+        return run_socks(cli, &sock, &xk, &auth_result, dns);
     }
 
     #[cfg(target_os = "linux")]
@@ -260,6 +262,7 @@ fn run_socks(
     sock: &std::net::UdpSocket,
     xor_key: &[u8],
     auth_result: &auth::AuthResult,
+    dns: iwan::core::socks::DnsResolver,
 ) -> Result<()> {
     let inner_ip = auth_result
         .tun
@@ -280,6 +283,7 @@ fn run_socks(
             sid: auth_result.sid,
             token: auth_result.tok,
             encryption: cli.encrypt,
+            dns,
         },
     )
 }
@@ -350,7 +354,24 @@ fn print_servers(servers: &[serde_json::Value]) {
     }
 }
 
-fn select_server(servers: &[serde_json::Value]) -> Result<&serde_json::Value> {
+fn select_server<'a>(
+    servers: &'a [serde_json::Value],
+    choice: Option<&str>,
+) -> Result<&'a serde_json::Value> {
+    if let Some(choice) = choice {
+        if let Ok(index) = choice.parse::<usize>() {
+            return servers
+                .get(index.wrapping_sub(1))
+                .with_context(|| format!("server index {index} out of range 1-{}", servers.len()))
+                .map(|s| s);
+        }
+        return servers
+            .iter()
+            .find(|s| s["name"].as_str().unwrap_or("").contains(choice))
+            .with_context(|| format!("no server name contains \"{choice}\""))
+            .map(|s| s);
+    }
+
     loop {
         print!("  Select server [1-{}]: ", servers.len());
         io::stdout().flush().ok();

--- a/src/bin/oidc/main.rs
+++ b/src/bin/oidc/main.rs
@@ -160,7 +160,7 @@ fn connect_server(cli: &cli::Cli, config: &LocalConfig) -> Result<()> {
     }
 
     let dns = iwan::core::socks::DnsResolver::parse(&cli.dns)
-        .with_context(|| format!("invalid --dns value {}", cli.dns))?;
+        .with_context(|| format!("invalid --dns value {:?}", cli.dns))?;
     let srv = select_server(&config.servers, cli.server.as_deref())?;
     let host = srv["host"].as_str().context("missing host")?;
     let port = srv["port"].as_u64().unwrap_or(6001) as u16;

--- a/src/bin/oidc/main.rs
+++ b/src/bin/oidc/main.rs
@@ -360,8 +360,9 @@ fn select_server<'a>(
 ) -> Result<&'a serde_json::Value> {
     if let Some(choice) = choice {
         if let Ok(index) = choice.parse::<usize>() {
-            return servers
-                .get(index.wrapping_sub(1))
+            return index
+                .checked_sub(1)
+                .and_then(|i| servers.get(i))
                 .with_context(|| format!("server index {index} out of range 1-{}", servers.len()))
                 .map(|s| s);
         }

--- a/src/core/netstack/dns.rs
+++ b/src/core/netstack/dns.rs
@@ -26,7 +26,9 @@ impl DnsResolver {
             return Ok(Self::Dot { host, port });
         }
         if spec.starts_with("https://") {
-            if !is_valid_doh_url(spec) {
+            let url = url::Url::parse(spec)
+                .with_context(|| format!("invalid DNS-over-HTTPS URL: {spec}"))?;
+            if url.host_str().is_none() || url.path().len() <= 1 {
                 anyhow::bail!("invalid DNS-over-HTTPS URL: {spec}");
             }
             return Ok(Self::Doh { url: spec.into() });
@@ -42,14 +44,6 @@ impl DnsResolver {
             .with_context(|| format!("invalid DNS resolver: {spec}"))?;
         Ok(Self::Udp(addr))
     }
-}
-
-fn is_valid_doh_url(url: &str) -> bool {
-    let rest = &url["https://".len()..];
-    let host_part = rest.split(['/', '?', '#']).next().unwrap_or("");
-    !host_part.is_empty()
-        && !host_part.contains(char::is_whitespace)
-        && rest.len() > host_part.len()
 }
 
 impl fmt::Display for DnsResolver {
@@ -68,7 +62,11 @@ fn split_host_port(spec: &str, default_port: u16) -> Result<(String, u16)> {
     }
     match spec.rsplit_once(':') {
         Some((host, port)) if !host.is_empty() => {
-            Ok((host.to_string(), port.parse().context("invalid DNS port")?))
+            let port = port.parse().context("invalid DNS port")?;
+            if port == 0 {
+                anyhow::bail!("invalid DNS port: {port}");
+            }
+            Ok((host.to_string(), port))
         }
         _ => Ok((spec.to_string(), default_port)),
     }
@@ -122,7 +120,7 @@ fn udp_query(query: &[u8], addr: SocketAddr) -> Result<Vec<u8>> {
     let (len, source) = socket
         .recv_from(&mut response)
         .context("receive DNS response")?;
-    if source.ip() != addr.ip() {
+    if source != addr {
         anyhow::bail!("DNS response from unexpected server {source}");
     }
     response.truncate(len);
@@ -314,9 +312,11 @@ mod tests {
             DnsResolver::Udp(addr) if addr.to_string() == "[2001:4860:4860::8888]:5353"
         ));
         assert!(DnsResolver::parse("tls://").is_err());
+        assert!(DnsResolver::parse("tls://dns.alidns.com:0").is_err());
         assert!(DnsResolver::parse("https://").is_err());
         assert!(DnsResolver::parse("https:// not a url").is_err());
         assert!(DnsResolver::parse("https://dns.alidns.com").is_err());
+        assert!(DnsResolver::parse("https://:443/dns-query").is_err());
         assert!(DnsResolver::parse("not a resolver").is_err());
     }
 

--- a/src/core/netstack/dns.rs
+++ b/src/core/netstack/dns.rs
@@ -26,21 +26,30 @@ impl DnsResolver {
             return Ok(Self::Dot { host, port });
         }
         if spec.starts_with("https://") {
+            if !is_valid_doh_url(spec) {
+                anyhow::bail!("invalid DNS-over-HTTPS URL: {spec}");
+            }
             return Ok(Self::Doh { url: spec.into() });
         }
         if let Ok(addr) = spec.parse::<SocketAddr>() {
             return Ok(Self::Udp(addr));
         }
-        let with_port = if spec.contains(':') {
-            spec.to_string()
-        } else {
-            format!("{spec}:53")
-        };
-        let addr: SocketAddr = with_port
+        if let Ok(ip) = spec.parse::<std::net::IpAddr>() {
+            return Ok(Self::Udp(SocketAddr::new(ip, 53)));
+        }
+        let addr: SocketAddr = format!("{spec}:53")
             .parse()
             .with_context(|| format!("invalid DNS resolver: {spec}"))?;
         Ok(Self::Udp(addr))
     }
+}
+
+fn is_valid_doh_url(url: &str) -> bool {
+    let rest = &url["https://".len()..];
+    let host_part = rest.split(['/', '?', '#']).next().unwrap_or("");
+    !host_part.is_empty()
+        && !host_part.contains(char::is_whitespace)
+        && rest.len() > host_part.len()
 }
 
 impl fmt::Display for DnsResolver {
@@ -58,10 +67,9 @@ fn split_host_port(spec: &str, default_port: u16) -> Result<(String, u16)> {
         anyhow::bail!("empty DNS host");
     }
     match spec.rsplit_once(':') {
-        Some((host, port)) if !host.is_empty() => Ok((
-            host.to_string(),
-            port.parse().context("invalid DNS port")?,
-        )),
+        Some((host, port)) if !host.is_empty() => {
+            Ok((host.to_string(), port.parse().context("invalid DNS port")?))
+        }
         _ => Ok((spec.to_string(), default_port)),
     }
 }
@@ -111,7 +119,9 @@ fn udp_query(query: &[u8], addr: SocketAddr) -> Result<Vec<u8>> {
         .with_context(|| format!("query DNS server {addr}"))?;
 
     let mut response = vec![0u8; 4096];
-    let (len, source) = socket.recv_from(&mut response).context("receive DNS response")?;
+    let (len, source) = socket
+        .recv_from(&mut response)
+        .context("receive DNS response")?;
     if source.ip() != addr.ip() {
         anyhow::bail!("DNS response from unexpected server {source}");
     }
@@ -128,13 +138,12 @@ fn dot_query(query: &[u8], host: &str, port: u16) -> Result<Vec<u8>> {
         .to_owned();
     let mut roots = RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let config = ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::ring::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .context("TLS protocol versions")?
-    .with_root_certificates(roots)
-    .with_no_client_auth();
+    let config =
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .context("TLS protocol versions")?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
 
     let mut stream = std::net::TcpStream::connect((host, port)).context("connect DNS-over-TLS")?;
     stream.set_read_timeout(Some(DNS_TIMEOUT))?;
@@ -149,7 +158,8 @@ fn dot_query(query: &[u8], host: &str, port: u16) -> Result<Vec<u8>> {
     std::io::Write::write_all(&mut tls, &frame).context("send DNS-over-TLS query")?;
 
     let mut len_buf = [0u8; 2];
-    tls.read_exact(&mut len_buf).context("read DNS-over-TLS length")?;
+    tls.read_exact(&mut len_buf)
+        .context("read DNS-over-TLS length")?;
     let len = u16::from_be_bytes(len_buf) as usize;
     let mut response = vec![0u8; len];
     tls.read_exact(&mut response)
@@ -295,7 +305,18 @@ mod tests {
             DnsResolver::parse("https://dns.alidns.com/dns-query").unwrap(),
             DnsResolver::Doh { url } if url == "https://dns.alidns.com/dns-query"
         ));
+        assert!(matches!(
+            DnsResolver::parse("2001:4860:4860::8888").unwrap(),
+            DnsResolver::Udp(addr) if addr.to_string() == "[2001:4860:4860::8888]:53"
+        ));
+        assert!(matches!(
+            DnsResolver::parse("[2001:4860:4860::8888]:5353").unwrap(),
+            DnsResolver::Udp(addr) if addr.to_string() == "[2001:4860:4860::8888]:5353"
+        ));
         assert!(DnsResolver::parse("tls://").is_err());
+        assert!(DnsResolver::parse("https://").is_err());
+        assert!(DnsResolver::parse("https:// not a url").is_err());
+        assert!(DnsResolver::parse("https://dns.alidns.com").is_err());
         assert!(DnsResolver::parse("not a resolver").is_err());
     }
 

--- a/src/core/netstack/dns.rs
+++ b/src/core/netstack/dns.rs
@@ -1,10 +1,70 @@
 use anyhow::{Context, Result};
-use std::net::{Ipv4Addr, UdpSocket};
+use std::fmt;
+use std::io::Read;
+use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::time::Duration;
 
-pub(crate) const DNS_SERVER: &str = "114.114.114.114:53";
+pub const DEFAULT_DNS: &str = "114.114.114.114:53";
 const DNS_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Clone, Debug)]
+pub enum DnsResolver {
+    Udp(SocketAddr),
+    Dot { host: String, port: u16 },
+    Doh { url: String },
+}
+
+impl DnsResolver {
+    /// Parse a resolver spec: `ip[:port]` (plain UDP), `tls://host[:port]`
+    /// (DNS over TLS) or `https://...` (DNS over HTTPS).
+    pub fn parse(spec: &str) -> Result<Self> {
+        let spec = spec.trim();
+        if let Some(rest) = spec.strip_prefix("tls://") {
+            let (host, port) = split_host_port(rest, 853)?;
+            return Ok(Self::Dot { host, port });
+        }
+        if spec.starts_with("https://") {
+            return Ok(Self::Doh { url: spec.into() });
+        }
+        if let Ok(addr) = spec.parse::<SocketAddr>() {
+            return Ok(Self::Udp(addr));
+        }
+        let with_port = if spec.contains(':') {
+            spec.to_string()
+        } else {
+            format!("{spec}:53")
+        };
+        let addr: SocketAddr = with_port
+            .parse()
+            .with_context(|| format!("invalid DNS resolver: {spec}"))?;
+        Ok(Self::Udp(addr))
+    }
+}
+
+impl fmt::Display for DnsResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Udp(addr) => write!(f, "{addr}"),
+            Self::Dot { host, port } => write!(f, "tls://{host}:{port}"),
+            Self::Doh { url } => write!(f, "{url}"),
+        }
+    }
+}
+
+fn split_host_port(spec: &str, default_port: u16) -> Result<(String, u16)> {
+    if spec.is_empty() {
+        anyhow::bail!("empty DNS host");
+    }
+    match spec.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => Ok((
+            host.to_string(),
+            port.parse().context("invalid DNS port")?,
+        )),
+        _ => Ok((spec.to_string(), default_port)),
+    }
+}
 
 pub(crate) struct DnsResult {
     pub(crate) flow_id: u64,
@@ -13,9 +73,15 @@ pub(crate) struct DnsResult {
     pub(crate) result: std::result::Result<Ipv4Addr, ()>,
 }
 
-pub(crate) fn spawn_ipv4_query(flow_id: u64, domain: String, port: u16, sender: Sender<DnsResult>) {
+pub(crate) fn spawn_ipv4_query(
+    flow_id: u64,
+    domain: String,
+    port: u16,
+    resolver: DnsResolver,
+    sender: Sender<DnsResult>,
+) {
     std::thread::spawn(move || {
-        let result = resolve_ipv4(&domain).map_err(|_| ());
+        let result = resolve_ipv4(&domain, &resolver).map_err(|_| ());
         let _ = sender.send(DnsResult {
             flow_id,
             domain,
@@ -25,24 +91,89 @@ pub(crate) fn spawn_ipv4_query(flow_id: u64, domain: String, port: u16, sender: 
     });
 }
 
-fn resolve_ipv4(domain: &str) -> Result<Ipv4Addr> {
+fn resolve_ipv4(domain: &str, resolver: &DnsResolver) -> Result<Ipv4Addr> {
     let query_id = rand::random();
     let query = build_a_query(query_id, domain)?;
+    let response = match resolver {
+        DnsResolver::Udp(addr) => udp_query(&query, *addr)?,
+        DnsResolver::Dot { host, port } => dot_query(&query, host, *port)?,
+        DnsResolver::Doh { url } => doh_query(&query, url)?,
+    };
+    parse_a_response(query_id, &response)
+}
+
+fn udp_query(query: &[u8], addr: SocketAddr) -> Result<Vec<u8>> {
     let socket = UdpSocket::bind("0.0.0.0:0").context("bind DNS socket")?;
     socket.set_read_timeout(Some(DNS_TIMEOUT))?;
     socket.set_write_timeout(Some(DNS_TIMEOUT))?;
     socket
-        .send_to(&query, DNS_SERVER)
-        .with_context(|| format!("query DNS server {DNS_SERVER}"))?;
+        .send_to(query, addr)
+        .with_context(|| format!("query DNS server {addr}"))?;
 
-    let mut response = [0u8; 4096];
-    let (len, source) = socket
-        .recv_from(&mut response)
-        .context("receive DNS response")?;
-    if source.ip() != Ipv4Addr::new(114, 114, 114, 114) {
+    let mut response = vec![0u8; 4096];
+    let (len, source) = socket.recv_from(&mut response).context("receive DNS response")?;
+    if source.ip() != addr.ip() {
         anyhow::bail!("DNS response from unexpected server {source}");
     }
-    parse_a_response(query_id, &response[..len])
+    response.truncate(len);
+    Ok(response)
+}
+
+fn dot_query(query: &[u8], host: &str, port: u16) -> Result<Vec<u8>> {
+    use rustls::pki_types::ServerName;
+    use rustls::{ClientConfig, ClientConnection, RootCertStore, Stream};
+
+    let server_name = ServerName::try_from(host)
+        .map_err(|_| anyhow::anyhow!("invalid DNS-over-TLS host: {host}"))?
+        .to_owned();
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let config = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .context("TLS protocol versions")?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+
+    let mut stream = std::net::TcpStream::connect((host, port)).context("connect DNS-over-TLS")?;
+    stream.set_read_timeout(Some(DNS_TIMEOUT))?;
+    stream.set_write_timeout(Some(DNS_TIMEOUT))?;
+    let mut conn =
+        ClientConnection::new(Arc::new(config), server_name).context("TLS handshake setup")?;
+    let mut tls = Stream::new(&mut conn, &mut stream);
+
+    let mut frame = Vec::with_capacity(2 + query.len());
+    frame.extend_from_slice(&(query.len() as u16).to_be_bytes());
+    frame.extend_from_slice(query);
+    std::io::Write::write_all(&mut tls, &frame).context("send DNS-over-TLS query")?;
+
+    let mut len_buf = [0u8; 2];
+    tls.read_exact(&mut len_buf).context("read DNS-over-TLS length")?;
+    let len = u16::from_be_bytes(len_buf) as usize;
+    let mut response = vec![0u8; len];
+    tls.read_exact(&mut response)
+        .context("read DNS-over-TLS response")?;
+    Ok(response)
+}
+
+fn doh_query(query: &[u8], url: &str) -> Result<Vec<u8>> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout(DNS_TIMEOUT)
+        .try_proxy_from_env(false)
+        .build();
+    let response = agent
+        .post(url)
+        .set("Content-Type", "application/dns-message")
+        .set("Accept", "application/dns-message")
+        .send_bytes(query)
+        .with_context(|| format!("query DNS-over-HTTPS server {url}"))?;
+    let mut body = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut body)
+        .context("read DNS-over-HTTPS response")?;
+    Ok(body)
 }
 
 fn build_a_query(id: u16, domain: &str) -> Result<Vec<u8>> {
@@ -141,6 +272,32 @@ fn skip_name(packet: &[u8], mut offset: usize) -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_resolver_specs() {
+        assert!(matches!(
+            DnsResolver::parse("223.5.5.5").unwrap(),
+            DnsResolver::Udp(addr) if addr.to_string() == "223.5.5.5:53"
+        ));
+        assert!(matches!(
+            DnsResolver::parse("223.5.5.5:5353").unwrap(),
+            DnsResolver::Udp(addr) if addr.to_string() == "223.5.5.5:5353"
+        ));
+        assert!(matches!(
+            DnsResolver::parse("tls://dns.alidns.com").unwrap(),
+            DnsResolver::Dot { host, port } if host == "dns.alidns.com" && port == 853
+        ));
+        assert!(matches!(
+            DnsResolver::parse("tls://dns.alidns.com:8543").unwrap(),
+            DnsResolver::Dot { port, .. } if port == 8543
+        ));
+        assert!(matches!(
+            DnsResolver::parse("https://dns.alidns.com/dns-query").unwrap(),
+            DnsResolver::Doh { url } if url == "https://dns.alidns.com/dns-query"
+        ));
+        assert!(DnsResolver::parse("tls://").is_err());
+        assert!(DnsResolver::parse("not a resolver").is_err());
+    }
 
     #[test]
     fn builds_and_parses_a_messages() {

--- a/src/core/netstack/dns.rs
+++ b/src/core/netstack/dns.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use std::fmt;
 use std::io::Read;
 use std::net::{Ipv4Addr, SocketAddr, UdpSocket};
+use std::num::NonZeroU16;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,7 +13,7 @@ const DNS_TIMEOUT: Duration = Duration::from_secs(3);
 #[derive(Clone, Debug)]
 pub enum DnsResolver {
     Udp(SocketAddr),
-    Dot { host: String, port: u16 },
+    Dot { host: String, port: NonZeroU16 },
     Doh { url: String },
 }
 
@@ -56,20 +57,43 @@ impl fmt::Display for DnsResolver {
     }
 }
 
-fn split_host_port(spec: &str, default_port: u16) -> Result<(String, u16)> {
+fn split_host_port(spec: &str, default_port: u16) -> Result<(String, NonZeroU16)> {
+    let default_port = NonZeroU16::new(default_port).expect("default DNS port is zero");
     if spec.is_empty() {
         anyhow::bail!("empty DNS host");
     }
-    match spec.rsplit_once(':') {
-        Some((host, port)) if !host.is_empty() => {
-            let port = port.parse().context("invalid DNS port")?;
-            if port == 0 {
-                anyhow::bail!("invalid DNS port: {port}");
-            }
-            Ok((host.to_string(), port))
+    let (host, port) = if let Some(rest) = spec.strip_prefix('[') {
+        let (host, tail) = rest
+            .split_once(']')
+            .ok_or_else(|| anyhow::anyhow!("unclosed bracket in DNS host: {spec}"))?;
+        let port = match tail.strip_prefix(':') {
+            Some(port) => parse_dns_port(port, spec)?,
+            None if tail.is_empty() => default_port,
+            None => anyhow::bail!("invalid DNS host: {spec}"),
+        };
+        (host.to_string(), port)
+    } else {
+        if spec.matches(':').count() > 1 {
+            anyhow::bail!("wrap IPv6 DNS hosts in brackets: [{spec}]");
         }
-        _ => Ok((spec.to_string(), default_port)),
+        match spec.rsplit_once(':') {
+            Some((host, port)) if !host.is_empty() => {
+                (host.to_string(), parse_dns_port(port, spec)?)
+            }
+            _ => (spec.to_string(), default_port),
+        }
+    };
+    if host.is_empty() {
+        anyhow::bail!("empty DNS host");
     }
+    Ok((host, port))
+}
+
+fn parse_dns_port(port: &str, spec: &str) -> Result<NonZeroU16> {
+    let port: u16 = port
+        .parse()
+        .with_context(|| format!("invalid DNS port in {spec}"))?;
+    NonZeroU16::new(port).ok_or_else(|| anyhow::anyhow!("invalid DNS port in {spec}"))
 }
 
 pub(crate) struct DnsResult {
@@ -102,27 +126,30 @@ fn resolve_ipv4(domain: &str, resolver: &DnsResolver) -> Result<Ipv4Addr> {
     let query = build_a_query(query_id, domain)?;
     let response = match resolver {
         DnsResolver::Udp(addr) => udp_query(&query, *addr)?,
-        DnsResolver::Dot { host, port } => dot_query(&query, host, *port)?,
+        DnsResolver::Dot { host, port } => dot_query(&query, host, port.get())?,
         DnsResolver::Doh { url } => doh_query(&query, url)?,
     };
     parse_a_response(query_id, &response)
 }
 
 fn udp_query(query: &[u8], addr: SocketAddr) -> Result<Vec<u8>> {
-    let socket = UdpSocket::bind("0.0.0.0:0").context("bind DNS socket")?;
+    let bind_addr = if addr.is_ipv6() {
+        "[::]:0"
+    } else {
+        "0.0.0.0:0"
+    };
+    let socket = UdpSocket::bind(bind_addr).context("bind DNS socket")?;
     socket.set_read_timeout(Some(DNS_TIMEOUT))?;
     socket.set_write_timeout(Some(DNS_TIMEOUT))?;
     socket
-        .send_to(query, addr)
+        .connect(addr)
+        .with_context(|| format!("connect DNS server {addr}"))?;
+    socket
+        .send(query)
         .with_context(|| format!("query DNS server {addr}"))?;
 
     let mut response = vec![0u8; 4096];
-    let (len, source) = socket
-        .recv_from(&mut response)
-        .context("receive DNS response")?;
-    if source != addr {
-        anyhow::bail!("DNS response from unexpected server {source}");
-    }
+    let len = socket.recv(&mut response).context("receive DNS response")?;
     response.truncate(len);
     Ok(response)
 }
@@ -293,11 +320,19 @@ mod tests {
         ));
         assert!(matches!(
             DnsResolver::parse("tls://dns.alidns.com").unwrap(),
-            DnsResolver::Dot { host, port } if host == "dns.alidns.com" && port == 853
+            DnsResolver::Dot { host, port } if host == "dns.alidns.com" && port.get() == 853
         ));
         assert!(matches!(
             DnsResolver::parse("tls://dns.alidns.com:8543").unwrap(),
-            DnsResolver::Dot { port, .. } if port == 8543
+            DnsResolver::Dot { port, .. } if port.get() == 8543
+        ));
+        assert!(matches!(
+            DnsResolver::parse("tls://[2001:db8::1]:853").unwrap(),
+            DnsResolver::Dot { host, port } if host == "2001:db8::1" && port.get() == 853
+        ));
+        assert!(matches!(
+            DnsResolver::parse("tls://[2001:db8::1]").unwrap(),
+            DnsResolver::Dot { host, port } if host == "2001:db8::1" && port.get() == 853
         ));
         assert!(matches!(
             DnsResolver::parse("https://dns.alidns.com/dns-query").unwrap(),
@@ -313,6 +348,8 @@ mod tests {
         ));
         assert!(DnsResolver::parse("tls://").is_err());
         assert!(DnsResolver::parse("tls://dns.alidns.com:0").is_err());
+        assert!(DnsResolver::parse("tls://2001:db8::1").is_err());
+        assert!(DnsResolver::parse("tls://[2001:db8::1").is_err());
         assert!(DnsResolver::parse("https://").is_err());
         assert!(DnsResolver::parse("https:// not a url").is_err());
         assert!(DnsResolver::parse("https://dns.alidns.com").is_err());

--- a/src/core/netstack/mod.rs
+++ b/src/core/netstack/mod.rs
@@ -3,5 +3,5 @@ pub(crate) mod dns;
 pub(crate) mod tunnel;
 
 pub(crate) use device::IpTunnelDevice;
-pub(crate) use dns::{spawn_ipv4_query, DnsResult, DNS_SERVER};
+pub(crate) use dns::{spawn_ipv4_query, DnsResult};
 pub(crate) use tunnel::{receive_vpn, send_vpn, send_vpn_keepalive, VPN_KEEPALIVE_INTERVAL};

--- a/src/core/socks.rs
+++ b/src/core/socks.rs
@@ -1,6 +1,6 @@
 use super::netstack::{
     receive_vpn, send_vpn, send_vpn_keepalive, spawn_ipv4_query, DnsResult, IpTunnelDevice,
-    DNS_SERVER, VPN_KEEPALIVE_INTERVAL,
+    VPN_KEEPALIVE_INTERVAL,
 };
 use super::{protocol, util};
 use anyhow::{Context, Result};
@@ -15,6 +15,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH};
+
+pub use super::netstack::dns::{DnsResolver, DEFAULT_DNS};
 
 const TCP_BUFFER_SIZE: usize = 256 * 1024;
 const LOCAL_WRITE_LIMIT: usize = 256 * 1024;
@@ -79,6 +81,7 @@ pub struct SocksConfig<'a> {
     pub sid: u16,
     pub token: u32,
     pub encryption: u8,
+    pub dns: DnsResolver,
 }
 
 pub fn run(sock: &UdpSocket, config: SocksConfig<'_>) -> Result<()> {
@@ -119,8 +122,8 @@ pub fn run(sock: &UdpSocket, config: SocksConfig<'_>) -> Result<()> {
     println!("SOCKS5 listening on {}", config.listen);
     if util::debug_enabled() {
         eprintln!(
-            "SOCKS5 network: IP {}, gateway {}, MTU {}",
-            config.inner_ip, config.gateway, config.mtu
+            "SOCKS5 network: IP {}, gateway {}, MTU {}, DNS {}",
+            config.inner_ip, config.gateway, config.mtu, config.dns
         );
     }
 
@@ -148,6 +151,7 @@ pub fn run(sock: &UdpSocket, config: SocksConfig<'_>) -> Result<()> {
             &mut sockets,
             &mut iface,
             config.inner_ip,
+            &config.dns,
             &mut next_port,
             &mut allocated_ports,
             &dns_tx,
@@ -158,6 +162,7 @@ pub fn run(sock: &UdpSocket, config: SocksConfig<'_>) -> Result<()> {
             &mut sockets,
             &mut iface,
             config.inner_ip,
+            &config.dns,
             &mut next_port,
             &mut allocated_ports,
         );
@@ -229,11 +234,13 @@ fn accept_connections(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn service_local_inputs(
     flows: &mut HashMap<u64, LocalFlow>,
     sockets: &mut SocketSet<'_>,
     iface: &mut Interface,
     inner_ip: Ipv4Addr,
+    dns: &DnsResolver,
     next_port: &mut u16,
     allocated_ports: &mut HashSet<u16>,
     dns_tx: &Sender<DnsResult>,
@@ -295,6 +302,7 @@ fn service_local_inputs(
                     sockets,
                     iface,
                     inner_ip,
+                    dns,
                     next_port,
                     allocated_ports,
                     dns_tx,
@@ -328,6 +336,7 @@ fn process_socks_handshake(
     sockets: &mut SocketSet<'_>,
     iface: &mut Interface,
     inner_ip: Ipv4Addr,
+    dns: &DnsResolver,
     next_port: &mut u16,
     allocated_ports: &mut HashSet<u16>,
     dns_tx: &Sender<DnsResult>,
@@ -390,7 +399,7 @@ fn process_socks_handshake(
             let domain = domain.to_string();
             flow.input.drain(..request_len);
             flow.set_state(LocalState::Resolving);
-            spawn_ipv4_query(id, domain, port, dns_tx.clone());
+            spawn_ipv4_query(id, domain, port, dns.clone(), dns_tx.clone());
             return;
         }
         _ => {
@@ -456,6 +465,7 @@ fn handle_dns_results(
     sockets: &mut SocketSet<'_>,
     iface: &mut Interface,
     inner_ip: Ipv4Addr,
+    dns: &DnsResolver,
     next_port: &mut u16,
     allocated_ports: &mut HashSet<u16>,
 ) {
@@ -489,7 +499,7 @@ fn handle_dns_results(
             Err(()) => {
                 eprintln!(
                     "[flow {}] DNS {} failed via {}",
-                    answer.flow_id, answer.domain, DNS_SERVER
+                    answer.flow_id, answer.domain, dns
                 );
                 queue_socks_error(flow, 4);
             }


### PR DESCRIPTION
## 动机

目前 `--connect` 需要交互式选择线路，无法用于 systemd 等无人值守场景；SOCKS5 模式下域名解析固定使用 `114.114.114.114:53`，在本地 DNS 被 TUN/fake-ip 类代理软件劫持的环境下会解析出假地址，导致隧道连接失败。

## 改动

### `--server`：非交互式选择线路

- `--server 电信`：按名称关键字匹配（子串）
- `--server 2`：按 1 开始的序号选择
- 不传该参数时保持原有交互式选择行为

`iwan-client` 与 `iwan-client-oidc` 均支持。

### `--dns`：自定义 SOCKS5 域名解析器

支持三种格式：

- `ip[:port]`：普通 UDP DNS（默认端口 53）
- `tls://host[:port]`：DNS over TLS（默认端口 853）
- `https://...`：DNS over HTTPS

默认值不变，仍为 `114.114.114.114:53`。当本地 DNS 被 fake-ip 类软件劫持时，可改用 DoT/DoH 规避，例如：

```bash
iwan-client-oidc --connect --server 电信 --socks --dns https://dns.alidns.com/dns-query
```

`--dns` 在认证之前即解析校验，格式错误会立即报错。

## 其他

- 为 resolver 格式解析补充了单元测试
- README 更新了相关说明
- DoT 使用 rustls（ring provider），DoH 复用已有的 ureq