### PR TITLE
延迟与上行吞吐优化

### DIFF
--- a/src/bin/client/proxy.rs
+++ b/src/bin/client/proxy.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use iwan::core::{auth, crypto, proxy, tun};
 use std::net::UdpSocket;
 use std::time::Duration;
+use std::os::fd::AsRawFd;
 
 pub fn run(args: &cli::ProxyArgs, nonce: u32, open: Vec<u8>) -> Result<()> {
     let addr: std::net::SocketAddr = format!("{}:{}", args.server, args.port)
@@ -10,6 +11,28 @@ pub fn run(args: &cli::ProxyArgs, nonce: u32, open: Vec<u8>) -> Result<()> {
         .context("invalid address")?;
     let sock = UdpSocket::bind("0.0.0.0:0").context("bind UDP")?;
     sock.connect(addr).context("connect UDP")?;
+
+    // Larger UDP buffers
+    {
+        const BUFSZ: libc::c_int = 16 * 1024 * 1024;
+        let fd = sock.as_raw_fd();
+        unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &BUFSZ as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&BUFSZ) as libc::socklen_t,
+            );
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_SNDBUF,
+                &BUFSZ as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&BUFSZ) as libc::socklen_t,
+            );
+        }
+    }
     sock.set_read_timeout(Some(Duration::from_millis(3000)))
         .ok();
 

--- a/src/core/proxy.rs
+++ b/src/core/proxy.rs
@@ -2,6 +2,7 @@ use super::{crypto, protocol, route, tun};
 use anyhow::{Context, Result};
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::os::fd::RawFd;
+use std::os::fd::AsRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -68,39 +69,53 @@ pub fn run_pump(
 
     let r1 = running.clone();
     let t1 = std::thread::spawn(move || {
-        let mut buf = vec![0u8; 2048];
-        let mut pfd = libc::pollfd {
-            fd: tun_fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
+        const BATCH: usize = 64;
+        const SLOT: usize = 2048;
+        let mut buf_slots = vec![0u8; BATCH * SLOT];
+        let mut iov:  [libc::iovec; BATCH]     = unsafe { std::mem::zeroed() };
+        let mut mmsg: [libc::mmsghdr; BATCH]   = unsafe { std::mem::zeroed() };
+        let hdr = protocol::pkhdr(protocol::PT_DATA_ENC, enc, sid, tok);
+
+        for i in 0..BATCH {
+            buf_slots[i * SLOT..i * SLOT + 8].copy_from_slice(&hdr);
+            iov[i] = libc::iovec {
+                iov_base: buf_slots[i * SLOT..].as_mut_ptr() as *mut _,
+                iov_len:  0,
+            };
+            mmsg[i].msg_hdr.msg_iov    = &mut iov[i];
+            mmsg[i].msg_hdr.msg_iovlen = 1;
+        }
+
+        let mut pfd = libc::pollfd { fd: tun_fd, events: libc::POLLIN, revents: 0 };
+        let mut cnt = 0usize;
+
         if super::util::debug_enabled() {
             eprintln!("[TUN→UDP] started");
         }
         loop {
-            if !r1.load(Ordering::Relaxed) {
-                break;
-            }
-            let n = tun::tun_read(tun_fd, &mut buf);
-            if n == -1 {
-                let e = std::io::Error::last_os_error();
-                if e.kind() == std::io::ErrorKind::WouldBlock {
-                    unsafe { libc::poll(&mut pfd, 1, 200) };
-                    continue;
+            if !r1.load(Ordering::Relaxed) { break; }
+
+            let s = &mut buf_slots[cnt * SLOT + 8..(cnt + 1) * SLOT];
+            let n = tun::tun_read(tun_fd, s);
+
+            if n > 0 {
+                let n = n as usize;
+                crypto::xor(&mut s[..n], &xk_send);
+                iov[cnt].iov_len = n + 8;
+                cnt += 1;
+                if cnt == BATCH {
+                    cnt = flush(&mut mmsg, cnt, sock_send.as_raw_fd());
                 }
-                r1.store(false, Ordering::Relaxed);
-                break;
-            }
-            if n <= 0 {
-                r1.store(false, Ordering::Relaxed);
-                break;
-            }
-            crypto::xor(&mut buf[..n as usize], &xk_send);
-            let h = protocol::pkhdr(protocol::PT_DATA_ENC, enc, sid, tok);
-            if sock_send
-                .send(&protocol::data_pkt(&h, &buf[..n as usize]))
-                .is_err()
-            {
+            } else if n == -1 {
+                match std::io::Error::last_os_error().kind() {
+                    std::io::ErrorKind::WouldBlock => {
+                        cnt = flush(&mut mmsg, cnt, sock_send.as_raw_fd());
+                        unsafe { libc::poll(&mut pfd, 1, 200) };
+                    }
+                    std::io::ErrorKind::Interrupted => {}
+                    _ => { r1.store(false, Ordering::Relaxed); break; }
+                }
+            } else {
                 r1.store(false, Ordering::Relaxed);
                 break;
             }
@@ -116,6 +131,14 @@ pub fn run_pump(
         let mut last_keepalive = Instant::now()
             .checked_sub(KEEPALIVE_INTERVAL)
             .unwrap_or_else(Instant::now);
+        let keepalive_pkt = protocol::ctrl_pkt(
+            &protocol::pkhdr(protocol::PT_ECHO_REQ, enc, sid, tok),
+            &[],
+        );
+        let echo_res_pkt = protocol::ctrl_pkt(
+            &protocol::pkhdr(protocol::PT_ECHO_RES, enc, sid, tok),
+            &[],
+        );
         if super::util::debug_enabled() {
             eprintln!("[UDP→TUN] started");
         }
@@ -124,8 +147,7 @@ pub fn run_pump(
                 break;
             }
             if last_keepalive.elapsed() >= KEEPALIVE_INTERVAL {
-                let h = protocol::pkhdr(protocol::PT_ECHO_REQ, enc, sid, tok);
-                if let Err(e) = sock_recv.send(&protocol::ctrl_pkt(&h, &[])) {
+                if let Err(e) = sock_recv.send(&keepalive_pkt) {
                     eprintln!("[UDP→TUN] keepalive send err: {e}");
                     r2.store(false, Ordering::Relaxed);
                     break;
@@ -145,8 +167,7 @@ pub fn run_pump(
                         r2.store(false, Ordering::Relaxed);
                         break;
                     } else if t == protocol::PT_ECHO_REQ {
-                        let h = protocol::pkhdr(protocol::PT_ECHO_RES, enc, sid, tok);
-                        if let Err(e) = sock_recv.send(&protocol::ctrl_pkt(&h, &[])) {
+                        if let Err(e) = sock_recv.send(&echo_res_pkt) {
                             eprintln!("[UDP→TUN] keepalive response err: {e}");
                             r2.store(false, Ordering::Relaxed);
                             break;
@@ -194,6 +215,27 @@ pub fn run_pump(
         eprintln!("CLOSE sent");
     }
     Ok(())
+}
+
+fn flush(mmsg: &mut [libc::mmsghdr], cnt: usize, fd: std::os::fd::RawFd) -> usize {
+    let mut off = 0usize;
+    while off < cnt {
+        let sent = unsafe {
+            libc::sendmmsg(fd, mmsg.as_mut_ptr().add(off), (cnt - off) as _, 0)
+        };
+        if sent < 0 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            if super::util::debug_enabled() {
+                let e = std::io::Error::last_os_error();
+                eprintln!("[TUN→UDP] sendmmsg: {e}, drop {} pkts", cnt - off);
+            }
+            break;
+        }
+        off += sent as usize;
+    }
+    0
 }
 
 fn expand_route_targets(targets: &[String]) -> Result<Vec<String>> {

--- a/src/core/proxy.rs
+++ b/src/core/proxy.rs
@@ -69,6 +69,11 @@ pub fn run_pump(
     let r1 = running.clone();
     let t1 = std::thread::spawn(move || {
         let mut buf = vec![0u8; 2048];
+        let mut pfd = libc::pollfd {
+            fd: tun_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
         if super::util::debug_enabled() {
             eprintln!("[TUN→UDP] started");
         }
@@ -80,7 +85,7 @@ pub fn run_pump(
             if n == -1 {
                 let e = std::io::Error::last_os_error();
                 if e.kind() == std::io::ErrorKind::WouldBlock {
-                    std::thread::sleep(Duration::from_millis(50));
+                    unsafe { libc::poll(&mut pfd, 1, 200) };
                     continue;
                 }
                 r1.store(false, Ordering::Relaxed);


### PR DESCRIPTION

## 问题
1. UDP socket 缓冲太小，突发到达时内核接收队列溢出
2. 上行泵读不到包时固定 `sleep(50ms)`，回程 ACK 转发延迟被人为抬高，cwnd 长不起来
3. 逐包 `send()` 系统调用开销成为瓶颈

## 改动内容

| 提交 | 改动 |
|---|---|
| `1afc82f` | UDP socket 缓冲区扩大为 16 MB |
| `9daae28` | 上行泵空转时改用 `poll()` 阻塞等待，替代 sleep |
| `b0758cc` | 上行 TUN 批量发送 UDP |

## 测试

基线 = `87beb82`（upstream/main HEAD），新旧二进制交错多轮对比：

**本地测试**：整形链路 750 Mbps + 15ms RTT，系统 UDP 默认缓冲调大至 16 MB，Mbit/s：

| 方向 | 修复前 | 修复后 |
|---|---|---|
| 下行 | 126.0 | **630.6** |
| 上行 | 83.7 | **652.6** |

注：缓冲区实际大小受 `net.core.rmem_max`/`wmem_max` 钳制，默认配置下建议酌情调大这两个 sysctl。
